### PR TITLE
Add nighttime flashlight gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,15 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Kick the Can</title>
+  <title>Kick the Can - Night Edition</title>
     <style>body{margin:0}</style>
     <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.js"></script>
   </head>
   <body>
+    <p style="color:white;font-family:Arial;background:#000;margin:0;padding:4px;">
+      Use arrow keys to move. Jail a hider by catching them in your flashlight
+      and then touching them.
+    </p>
     <script src="game.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add nighttime background and flashlight mask
- hide hiders in darkness until flashlight reveals them
- require flashlight for captures and show caught message
- update title and instructions for night edition

## Testing
- `node --check game.js`
